### PR TITLE
Colorful meshes in `viz3d.py`

### DIFF
--- a/microviewer/viz3d.py
+++ b/microviewer/viz3d.py
@@ -183,6 +183,24 @@ def objects(
 
   display_actors(segids, actors)
 
+
+def recenter_camera_on_click(picker, interactor, renderer):
+        
+    def recenter(_obj, _evt):
+        x, y = interactor.GetEventPosition()
+        if picker.Pick(x, y, 0, renderer):      
+            fp_new = np.array(picker.GetPickPosition())
+
+            cam = renderer.GetActiveCamera()
+            offset = np.array(cam.GetPosition()) - np.array(cam.GetFocalPoint())
+
+            cam.SetFocalPoint(*fp_new)          
+            cam.SetPosition(*(fp_new + offset)) 
+            renderer.ResetCameraClippingRange() 
+            interactor.Render()
+
+    interactor.AddObserver("RightButtonPressEvent", recenter)
+
 def display_actors(segids, actors):
   if len(actors) == 0:
     return
@@ -209,6 +227,9 @@ def display_actors(segids, actors):
   for actor in actors:
     renderer.AddActor(actor)
 
+  picker = vtk.vtkCellPicker()
+  recenter_camera_on_click(picker, interactor, renderer)
+  
   window_name = f"Mesh & Skeleton Viewer"
   if segids:
     segids = [ str(x) for x in segids ]


### PR DESCRIPTION
I am integrating `microviewer` into `skeliner` and sometimes we want to visualize multiple pairs of meshes and skeletons at the same time. It would be great if the meshes can be in different colors.


<img width="1112" alt="Screenshot 2025-06-20 at 11 33 37" src="https://github.com/user-attachments/assets/a3aa8b13-1583-48c2-a871-f74ce9a0901f" />

```python
import skeliner as sk
import matplotlib.cm as cm

name = [720575940552301329, 720575940554769884, 720575940556472535, 720575940560499902, 720575940564337565,
        720575940554550834, 720575940555141886, 720575940558814886, 720575940562055087, 720575940569769761]
meshes = [sk.io.load_mesh(f"../../../flatone/output/{n}/mesh_warped.ctm") for n in name]
skels = [sk.io.load_swc(f"../../../flatone/output/{n}/skeleton_warped.swc") for n in name]

sk.view3d(skels=skels, meshes=meshes, scale=(1, 1e-3), mesh_color=cm.tab20.colors)
```

So, with this PR, it calls `objects([box, *zm_meshes, *ost_skels], mesh_color=mesh_color)` under the hood, where the newly added `mesh_color: str|Sequence`  defaults to `same`, which will be the same as before (white), or can be `diff` (loop through the COLORS + BBOX_COLORS already in the file), or be an user-provided list of colors (any matplotlib.cm should work).

